### PR TITLE
enable ordered lists in styles.css

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -275,8 +275,11 @@ ul {
 }
 
 li {
-    list-style-type: circle;
     list-style-position: inside;
+}
+
+ul>li {
+    list-style-type: circle;
 }
 
 


### PR DESCRIPTION
Hey there! This is my favorite Hugo theme, so thanks for making it! I was just writing a list this morning and I noticed that, even if you create an ordered list in Markdown like 
1. Item 1
2. Item 2
it still comes out with open circles instead of numbers, as you would see in an unordered list. I recognize that this might be a stylistic choice, so feel free to disregard this pr, but I just added a quick couple lines of code to enable ordered lists.  Have a great day!