### PR TITLE
Fix duplicate about nav link naming for tags

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -48,6 +48,7 @@ hasCJKLanguage = true
 	about = ""
 	archive = ""
 	subscribe = ""
+	tags = ""
 	# Pagination links
 	olderPosts = ""
 	newerPosts = ""

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -4,7 +4,7 @@
 		<a href='{{ .Site.BaseURL }}'> <span class="arrow">←</span>{{ with .Site.Params.home }}{{ . }}{{ else }}Home{{ end }}</a>
 	{{ end }}
 	<a href='{{ .Site.BaseURL }}post'>{{ with .Site.Params.archive }}{{ . }}{{ else }}Archive{{ end }}</a>
-	<a href='{{ .Site.BaseURL }}tags'>{{ with .Site.Params.about }}{{ . }}{{ else }}Tags{{ end }}</a>
+	<a href='{{ .Site.BaseURL }}tags'>{{ with .Site.Params.tags }}{{ . }}{{ else }}Tags{{ end }}</a>
 	<a href='{{ .Site.BaseURL }}about'>{{ with .Site.Params.about }}{{ . }}{{ else }}About{{ end }}</a>
 
 	{{ range $key, $val := .Site.Params.Links }}


### PR DESCRIPTION
Fix duplicate of the `about` navbar link which replaces the `tags` navbar link.

**config.toml**
```toml
about = "about1"
tags = "tags1"
```

**Error**
![error](https://user-images.githubusercontent.com/2503518/28774033-2557160c-762f-11e7-83d2-5d3b00c0277e.png)

 **Fixed**
![fixed](https://user-images.githubusercontent.com/2503518/28774035-2807e9ee-762f-11e7-8f19-208aa799583f.png)
