### PR TITLE
Fixes #26 Allow a post or about page to disable comments

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -40,11 +40,15 @@
             {{ end }}
 
             {{ if .Site.Params.enableDisqus }}
-                {{ partial "disqus.html" . }}
+                {{ if eq .Params.disabledisqus "true" }}
+                    {{ partial "disqus.html" . }}
+                {{ end }}
             {{ end }}
 
             {{ if .Site.Params.enableDuoshuo }}
-                {{ partial "duoshuo.html" . }}
+                {{ if eq .Params.disableduoshuo "true" }}
+                    {{ partial "duoshuo.html" . }}
+                {{ end }}
             {{ end }}
 
             {{ partial "footer.html" . }}

--- a/layouts/section/about.html
+++ b/layouts/section/about.html
@@ -7,11 +7,15 @@
     {{ .Content }}
 
     {{ if .Site.Params.enableDisqus }}
-        {{ partial "disqus.html" . }}
+        {{ if eq .Params.disabledisqus "true" }}
+            {{ partial "disqus.html" . }}
+        {{ end }}
     {{ end }}
 
     {{ if .Site.Params.enableDuoshuo }}
-        {{ partial "duoshuo.html" . }}
+        {{ if eq .Params.disableduoshuo "true" }}
+            {{ partial "duoshuo.html" . }}
+        {{ end }}
     {{ end }}
 
     {{ partial "footer.html" . }}


### PR DESCRIPTION
This allows disabledisqus or disableduoshuo to be added to the front matter which will disable the chat for a given post or about page.