### PR TITLE
Correct grammar in reading time estimate

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -11,7 +11,7 @@
                     <h2 class="headline">
                     {{ .Date.Format "Jan 2, 2006 15:04" }}
                     · {{ if lt 1 .WordCount }}{{ .WordCount }} words{{ else }}{{ .WordCount }} word{{ end }}
-                    · {{ if eq 1 .ReadingTime }}{{ .ReadingTime }} minute read{{ else }}{{ .ReadingTime }} minutes read{{ end }}
+                    · {{ .ReadingTime }} minute read
                       <span class="tags">
                       {{ with .Params.tags }}
                       {{ if ge (len .) 1 }}


### PR DESCRIPTION
In English, it's always "x minute read", regardless of how many minutes.