### PR TITLE
update UL list style

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -277,7 +277,7 @@ li {
 }
 
 ul>li {
-    list-style-type: circle;
+    list-style-type: disc;
 }
 
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -271,7 +271,9 @@ ul {
 }
 
 li {
-    list-style-position: inside;
+    list-style-position: outside;
+    /* text-indent: -1.5em; */
+    margin-left: 1.5em;
 }
 
 ul>li {


### PR DESCRIPTION
the current list style has - IMHO - two flaws:

* the "circle" style is barely visible on my retina mac, the circle is way too thin and hard to see
* for multi-line LIs the 2nd line is not "in sync" with the first line, but with the outer paragraph

that creates a - again, IMHO - very unpleasant reading experience with unordered lists. so I changed the list style to "outer", set an indent, and changed the list style to "disc".

I think it is much nicer that way, if you also like it please merge. :)