### PR TITLE
fix page turning issue in i18n of zh

### DIFF
--- a/i18n/zh.yaml
+++ b/i18n/zh.yaml
@@ -36,10 +36,10 @@ wordCount:
   other: "{{ .WordCount }}字"
 
 postsNewer:
-  other: 下一页
+  other: 上一页
 
 postsOlder:
-  other: 上一页
+  other: 下一页
 
 poweredBy:
   other: >-


### PR DESCRIPTION
在英文场景在”Older posts“合理
<img width="666" alt="image" src="https://github.com/nodejh/hugo-theme-mini/assets/62556743/4dafd808-d6a9-4cc7-a973-651c011acd2d">
似乎在中文场景下翻页显示为”下一页“合理一点
<img width="681" alt="image" src="https://github.com/nodejh/hugo-theme-mini/assets/62556743/82c2a96b-072d-4896-a2ca-e60650187abd">
<img width="702" alt="image" src="https://github.com/nodejh/hugo-theme-mini/assets/62556743/08e37ddd-92af-495a-b3b1-d0b816ad6571">
