### PR TITLE
Update deprecated Site.Social

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 <footer id="footer">
-    {{ if .Site.Social }}
+    {{ if .Site.Params.Social }}
         {{ partial "social.html" . }}
     {{ end }}
 

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -1,6 +1,6 @@
 <div id="social">
 
-{{ range $key, $val := .Site.Social }}
+{{ range $key, $val := .Site.Params.Social }}
     <a class="symbol" href="{{ $val }}" rel="me" target="_blank">
         {{ $svg :=  print "svgs/" $key ".svg" }}
         {{ partial $svg (dict "fill" "#bbbbbb" "width" 28 "height" 28 ) }}


### PR DESCRIPTION
Hi!

I changed `.Site.Social` to `.Site.Params.Social`. Locally, this seems to fix the issue I opened (https://github.com/nodejh/hugo-theme-mini/issues/167) which deals with the following deprecation error:

```
ERROR deprecated: .Site.Social was deprecated in Hugo v0.124.0 and will be removed in Hugo 0.139.0. Implement taxonomy 'social' or use .Site.Params.Social instead.
```

I don't know if it will cause problems for people with an older version of hugo.