### PR TITLE
Fix deprecated site social tag

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,34 +1,26 @@
 <footer id="footer">
-    {{ if .Site.Social }}
-        {{ partial "social.html" . }}
-    {{ end }}
+  {{ if .Site.Params.Social }} {{ partial "social.html" . }} {{ end }}
 
-    <div class="copyright">
-    {{ with .Site.Params.copyright }}
-        {{ . | markdownify }}
-    {{ else }}
-       © Copyright 
-       {{ now.Format "2006"}} 
-       <span class="split">
-        {{ partial "svgs/heart.svg" (dict "fill" "#bbbbbb" "width" 15 "height" 15 ) }}
-       </span>
-       {{ .Site.Params.Author }}
-    {{ end }}
-    </div>
+  <div class="copyright">
+    {{ with .Site.Params.copyright }} {{ . | markdownify }} {{ else }} ©
+    Copyright {{ now.Format "2006"}}
+    <span class="split">
+      {{ partial "svgs/heart.svg" (dict "fill" "#bbbbbb" "width" 15 "height" 15
+      ) }}
+    </span>
+    {{ .Site.Params.Author }} {{ end }}
+  </div>
 
-    {{ if ne .Site.Params.showPowerBy false }}
-      <div class="powerby">
-        {{ i18n "poweredBy" | safeHTML }}
-      </div>
-    {{ end }}
+  {{ if ne .Site.Params.showPowerBy false }}
+  <div class="powerby">{{ i18n "poweredBy" | safeHTML }}</div>
+  {{ end }}
 </footer>
 
-{{ range .Site.Params.customJS }}
-    {{ if ( or ( hasPrefix . "http://" ) ( hasPrefix . "https://" ) ) }}
-        <!-- remote js -->
-        <script src="{{ . }}"></script>
-    {{ else }}
-        <!-- local js -->
-        <script src="{{ $.Site.BaseURL }}{{ . }}"></script>
-    {{ end }}
-{{ end }}
+{{ range .Site.Params.customJS }} {{ if ( or ( hasPrefix . "http://" ) (
+hasPrefix . "https://" ) ) }}
+<!-- remote js -->
+<script src="{{ . }}"></script>
+{{ else }}
+<!-- local js -->
+<script src="{{ $.Site.BaseURL }}{{ . }}"></script>
+{{ end }} {{ end }}

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -1,10 +1,8 @@
 <div id="social">
-
-{{ range $key, $val := .Site.Social }}
-    <a class="symbol" href="{{ $val }}" rel="me" target="_blank">
-        {{ $svg :=  print "svgs/" $key ".svg" }}
-        {{ partial $svg (dict "fill" "#bbbbbb" "width" 28 "height" 28 ) }}
-    </a>
-{{ end }}
-
+  {{ range $key, $val := .Site.Params.Social }}
+  <a class="symbol" href="{{ $val }}" rel="me" target="_blank">
+    {{ $svg := print "svgs/" $key ".svg" }} {{ partial $svg (dict "fill"
+    "#bbbbbb" "width" 28 "height" 28 ) }}
+  </a>
+  {{ end }}
 </div>


### PR DESCRIPTION
`Site.social` has been deprecated, and building has become impossible without upgrading it to `Site.Params`.
This PR fixes the issue.